### PR TITLE
s/nord/nevil in composer-init

### DIFF
--- a/usr/share/regolith-look/nevil/compositor-init
+++ b/usr/share/regolith-look/nevil/compositor-init
@@ -12,5 +12,5 @@ done
 if [[ -f "$HOME/.config/regolith2/picom/config" ]]; then
   /usr/bin/picom --config "$HOME/.config/regolith2/picom/config"
 else
-  /usr/bin/picom --config /usr/share/regolith-look/nord/picom.conf
+  /usr/bin/picom --config /usr/share/regolith-look/nevil/picom.conf
 fi


### PR DESCRIPTION
This PR is to fix a small mistake I noticed in the nevil look configuration.