### PR TITLE
Changed default nevil icon theme to Moka

### DIFF
--- a/usr/share/regolith-look/nevil/root
+++ b/usr/share/regolith-look/nevil/root
@@ -13,7 +13,7 @@ regolith.look: nevil
 ! --------------------------------------------
 
 gtk.theme_name: WhiteSur-light
-gtk.icon_theme_name: Arc
+gtk.icon_theme_name: Moka
 
 ! --------------------------------------------
 ! -- Picom Compositor Config


### PR DESCRIPTION
I noticed that the default icon theme for Nevil, Arc, has wifi icons that are too light to show up on the light-themed bar. This just changes it to Moka. See screen shots.

![arc-missing-wifi](https://user-images.githubusercontent.com/198450/176454207-0489e08f-478b-4286-964a-2cdfaf354b90.png)
![moka-wifi-present](https://user-images.githubusercontent.com/198450/176454224-1f9576d4-746a-421d-b730-d96b10b42e95.png)

