### PR TITLE
Add i3-default look

### DIFF
--- a/usr/share/regolith-look/ayu-dark/i3-wm
+++ b/usr/share/regolith-look/ayu-dark/i3-wm
@@ -1,8 +1,10 @@
-#define i3wm_window_border_size         3
-#define i3wm_floatingwindow_border_size 3
-#define i3wm_gaps_inner_size            5
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               bottom
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          3
+#define i3wm_floatingwindow_border_size  3
+#define i3wm_gaps_inner_size             5
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
@@ -52,7 +54,9 @@ i3-wm.client.urgent.color.text: color_black
 i3-wm.client.urgent.color.indicator: color_red
 i3-wm.client.urgent.color.child_border: color_red
 
+i3-wm.window.border.style: i3wm_window_border_style
 i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
 i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
 i3-wm.gaps.inner.size: i3wm_gaps_inner_size
 i3-wm.gaps.outer.size: i3wm_gaps_outer_size

--- a/usr/share/regolith-look/ayu-mirage/i3-wm
+++ b/usr/share/regolith-look/ayu-mirage/i3-wm
@@ -1,8 +1,10 @@
-#define i3wm_window_border_size         3
-#define i3wm_floatingwindow_border_size 3
-#define i3wm_gaps_inner_size            5
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               bottom
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          3
+#define i3wm_floatingwindow_border_size  3
+#define i3wm_gaps_inner_size             5
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
@@ -52,7 +54,9 @@ i3-wm.client.urgent.color.text: color_black
 i3-wm.client.urgent.color.indicator: color_red
 i3-wm.client.urgent.color.child_border: color_red
 
+i3-wm.window.border.style: i3wm_window_border_style
 i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
 i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
 i3-wm.gaps.inner.size: i3wm_gaps_inner_size
 i3-wm.gaps.outer.size: i3wm_gaps_outer_size

--- a/usr/share/regolith-look/ayu/i3-wm
+++ b/usr/share/regolith-look/ayu/i3-wm
@@ -1,8 +1,10 @@
-#define i3wm_window_border_size         3
-#define i3wm_floatingwindow_border_size 3
-#define i3wm_gaps_inner_size            5
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               bottom
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          3
+#define i3wm_floatingwindow_border_size  3
+#define i3wm_gaps_inner_size             5
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
@@ -52,7 +54,9 @@ i3-wm.client.urgent.color.text: color_black
 i3-wm.client.urgent.color.indicator: color_red
 i3-wm.client.urgent.color.child_border: color_red
 
+i3-wm.window.border.style: i3wm_window_border_style
 i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
 i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
 i3-wm.gaps.inner.size: i3wm_gaps_inner_size
 i3-wm.gaps.outer.size: i3wm_gaps_outer_size

--- a/usr/share/regolith-look/blackhole/i3-wm
+++ b/usr/share/regolith-look/blackhole/i3-wm
@@ -1,8 +1,10 @@
-#define i3wm_window_border_size         1
-#define i3wm_floatingwindow_border_size 1
-#define i3wm_gaps_inner_size            0
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               bottom
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          1
+#define i3wm_floatingwindow_border_size  1
+#define i3wm_gaps_inner_size             0
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
@@ -52,7 +54,9 @@ i3-wm.client.urgent.color.text: color_base3
 i3-wm.client.urgent.color.indicator: color_red
 i3-wm.client.urgent.color.child_border: color_base03
 
+i3-wm.window.border.style: i3wm_window_border_style
 i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
 i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
 i3-wm.gaps.inner.size: i3wm_gaps_inner_size
 i3-wm.gaps.outer.size: i3wm_gaps_outer_size

--- a/usr/share/regolith-look/dracula/i3-wm
+++ b/usr/share/regolith-look/dracula/i3-wm
@@ -1,8 +1,10 @@
-#define i3wm_window_border_size         2
-#define i3wm_floatingwindow_border_size 2
-#define i3wm_gaps_inner_size            5
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               bottom
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          2
+#define i3wm_floatingwindow_border_size  2
+#define i3wm_gaps_inner_size             5
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
@@ -52,7 +54,9 @@ i3-wm.client.urgent.color.text: color_base0
 i3-wm.client.urgent.color.indicator: color_red
 i3-wm.client.urgent.color.child_border: color_red
 
+i3-wm.window.border.style: i3wm_window_border_style
 i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
 i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
 i3-wm.gaps.inner.size: i3wm_gaps_inner_size
 i3-wm.gaps.outer.size: i3wm_gaps_outer_size

--- a/usr/share/regolith-look/gruvbox/i3-wm
+++ b/usr/share/regolith-look/gruvbox/i3-wm
@@ -1,8 +1,11 @@
-#define i3wm_window_border_size         4
-#define i3wm_floatingwindow_border_size 2
-#define i3wm_gaps_inner_size            6
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               top
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          4
+#define i3wm_floatingwindow_border_size  2
+#define i3wm_gaps_inner_size             6
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                top
+
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
@@ -52,7 +55,9 @@ i3-wm.client.urgent.color.text: color_base3
 i3-wm.client.urgent.color.indicator: color_red
 i3-wm.client.urgent.color.child_border: color_base03
 
+i3-wm.window.border.style: i3wm_window_border_style
 i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
 i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
 i3-wm.gaps.inner.size: i3wm_gaps_inner_size
 i3-wm.gaps.outer.size: i3wm_gaps_outer_size

--- a/usr/share/regolith-look/i3-default/compositor-init
+++ b/usr/share/regolith-look/i3-default/compositor-init
@@ -1,0 +1,16 @@
+#!/bin/bash
+# See https://regolith-linux.org/docs/customize/compositors/
+
+compositor_PID=$(pidof picom)
+
+while [ ! -z "$compositor_PID" ]; do
+  kill $compositor_PID
+  sleep .1
+  compositor_PID=$(pidof picom)
+done
+
+if [[ -f "$HOME/.config/regolith2/picom/config" ]]; then
+  /usr/bin/picom --config "$HOME/.config/regolith2/picom/config"
+else
+  /usr/bin/picom --config /usr/share/regolith-look/i3-default/picom.conf
+fi

--- a/usr/share/regolith-look/i3-default/gnome-terminal
+++ b/usr/share/regolith-look/i3-default/gnome-terminal
@@ -1,0 +1,21 @@
+gnome.terminal.color0:    color_terminal_0
+gnome.terminal.color1:    color_terminal_1
+gnome.terminal.color2:    color_terminal_2
+gnome.terminal.color3:    color_terminal_3
+gnome.terminal.color4:    color_terminal_4
+gnome.terminal.color5:    color_terminal_5
+gnome.terminal.color6:    color_terminal_6
+gnome.terminal.color7:    color_terminal_7
+gnome.terminal.color8:    color_terminal_8
+gnome.terminal.color9:    color_terminal_9
+gnome.terminal.color10:   color_terminal_10
+gnome.terminal.color11:   color_terminal_11
+gnome.terminal.color12:   color_terminal_12
+gnome.terminal.color13:   color_terminal_13
+gnome.terminal.color14:   color_terminal_14
+gnome.terminal.color15:   color_terminal_15
+
+gnome.terminal.font:      gtk_monospace_font_name
+gnome.terminal.scrollbar: never
+gnome.terminal.background-transparency-percent: 0
+gnome.terminal.use-transparent-background: false

--- a/usr/share/regolith-look/i3-default/i3-wm
+++ b/usr/share/regolith-look/i3-default/i3-wm
@@ -1,0 +1,82 @@
+#define i3wm_window_border_style         normal
+#define i3wm_floatingwindow_border_style normal
+#define i3wm_window_border_size          2
+#define i3wm_floatingwindow_border_size  2
+#define i3wm_gaps_inner_size             0
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
+
+#define Q(x) #x
+#define QUOTE(x) Q(x)
+#define glyph_font QUOTE(gtk_monospace_font_name)
+#define glyph typeface_bar_glyph_workspace
+
+ilia.stylesheet: /usr/share/regolith-look/i3-default/ilia.css
+
+i3-wm.bar.position: i3wm_bar_position
+i3-wm.bar.background.color: color_bar_background
+i3-wm.bar.statusline.color: color_bar_statusline
+i3-wm.bar.separator.color: color_bar_separator
+i3-wm.bar.workspace.focused.border.color: color_bar_workspace_focused_border
+i3-wm.bar.workspace.focused.background.color: color_bar_workspace_focused_background
+i3-wm.bar.workspace.focused.text.color: color_bar_workspace_focused_text
+i3-wm.bar.workspace.active.border.color: color_bar_workspace_active_border
+i3-wm.bar.workspace.active.background.color: color_bar_workspace_active_background
+i3-wm.bar.workspace.active.text.color: color_bar_workspace_active_text
+i3-wm.bar.workspace.inactive.border.color: color_bar_workspace_inactive_border
+i3-wm.bar.workspace.inactive.background.color: color_bar_workspace_inactive_background
+i3-wm.bar.workspace.inactive.text.color: color_bar_workspace_inactive_text
+i3-wm.bar.workspace.urgent.border.color: color_bar_workspace_urgent_border
+i3-wm.bar.workspace.urgent.background.color: color_bar_workspace_urgent_background
+i3-wm.bar.workspace.urgent.text.color: color_bar_workspace_urgent_text
+
+i3-wm.client.focused.color.border: color_client_focused_border
+i3-wm.client.focused.color.background: color_client_focused_background
+i3-wm.client.focused.color.text: color_client_focused_text
+i3-wm.client.focused.color.indicator: color_client_focused_indicator
+i3-wm.client.focused.color.child_border: color_client_focused_child_border
+
+i3-wm.client.focused_inactive.color.border: color_client_focused_inactive_border
+i3-wm.client.focused_inactive.color.background: color_client_focused_inactive_background
+i3-wm.client.focused_inactive.color.text: color_client_focused_inactive_text
+i3-wm.client.focused_inactive.color.indicator: color_client_focused_inactive_indicator
+i3-wm.client.focused_inactive.color.child_border: color_client_focused_inactive_child_border
+
+i3-wm.client.unfocused.color.border: color_client_unfocused_border
+i3-wm.client.unfocused.color.background: color_client_unfocused_background
+i3-wm.client.unfocused.color.text: color_client_unfocused_text
+i3-wm.client.unfocused.color.indicator: color_client_unfocused_indicator
+i3-wm.client.unfocused.color.child_border: color_client_unfocused_child_border
+
+i3-wm.client.urgent.color.border: color_client_urgent_border
+i3-wm.client.urgent.color.background: color_client_urgent_background
+i3-wm.client.urgent.color.text: color_client_urgent_text
+i3-wm.client.urgent.color.indicator: color_client_urgent_indicator
+i3-wm.client.urgent.color.child_border: color_client_urgent_child_border
+
+i3-wm.window.border.style: i3wm_window_border_style
+i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
+i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
+i3-wm.gaps.inner.size: i3wm_gaps_inner_size
+i3-wm.gaps.outer.size: i3wm_gaps_outer_size
+
+i3-wm.workspace.01.name: 1
+i3-wm.workspace.02.name: 2
+i3-wm.workspace.03.name: 3
+i3-wm.workspace.04.name: 4
+i3-wm.workspace.05.name: 5
+i3-wm.workspace.06.name: 6
+i3-wm.workspace.07.name: 7
+i3-wm.workspace.08.name: 8
+i3-wm.workspace.09.name: 9
+i3-wm.workspace.10.name: 10
+i3-wm.workspace.11.name: 11
+i3-wm.workspace.12.name: 12
+i3-wm.workspace.13.name: 13
+i3-wm.workspace.14.name: 14
+i3-wm.workspace.15.name: 15
+i3-wm.workspace.16.name: 16
+i3-wm.workspace.17.name: 17
+i3-wm.workspace.18.name: 18
+i3-wm.workspace.19.name: 19

--- a/usr/share/regolith-look/i3-default/i3xrocks
+++ b/usr/share/regolith-look/i3-default/i3xrocks
@@ -1,0 +1,89 @@
+#define typeface_bar_glyph_app_launcher 
+#define typeface_bar_glyph_battery_0 
+#define typeface_bar_glyph_battery_100 
+#define typeface_bar_glyph_battery_20 
+#define typeface_bar_glyph_battery_50 
+#define typeface_bar_glyph_battery_80 
+#define typeface_bar_glyph_battery_ac 
+#define typeface_bar_glyph_battery_charging 
+#define typeface_bar_glyph_battery_unknown 
+#define typeface_bar_glyph_capslock 
+#define typeface_bar_glyph_cpu 
+#define typeface_bar_glyph_disk 
+#define typeface_bar_glyph_dn 
+#define typeface_bar_glyph_error 
+#define typeface_bar_glyph_help 
+#define typeface_bar_glyph_media_paused 
+#define typeface_bar_glyph_media_playing 
+#define typeface_bar_glyph_memory 
+#define typeface_bar_glyph_mute 
+#define typeface_bar_glyph_next_workspace 
+#define typeface_bar_glyph_notify_error 
+#define typeface_bar_glyph_notify_none 
+#define typeface_bar_glyph_notify_some 
+#define typeface_bar_glyph_numlock 
+#define typeface_bar_glyph_off 
+#define typeface_bar_glyph_on 
+#define typeface_bar_glyph_sound 
+#define typeface_bar_glyph_thermometer 
+#define typeface_bar_glyph_time 
+#define typeface_bar_glyph_up 
+#define typeface_bar_glyph_wifi 
+#define typeface_bar_glyph_wired 
+#define typeface_bar_glyph_workspace 
+
+i3xrocks.label.color:       color_i3xrocks_label
+i3xrocks.value.color:       color_i3xrocks_value
+i3xrocks.value.font:        gtk_monospace_font_name
+i3xrocks.critical.color:    color_i3xrocks_critical
+i3xrocks.error.color:       color_i3xrocks_error
+i3xrocks.warning:           color_i3xrocks_warning
+i3xrocks.nominal:           color_i3xrocks_nominal
+
+i3xrocks.label.thermometer: typeface_bar_glyph_thermometer
+
+i3xrocks.label.wifi: typeface_bar_glyph_wifi
+i3xrocks.label.wired: typeface_bar_glyph_wired
+i3xrocks.label.up: typeface_bar_glyph_up
+i3xrocks.label.dn: typeface_bar_glyph_dn
+
+i3xrocks.label.cpu: typeface_bar_glyph_cpu
+
+i3xrocks.label.disk: typeface_bar_glyph_disk
+
+i3xrocks.label.battery100: typeface_bar_glyph_battery_100
+i3xrocks.label.battery80: typeface_bar_glyph_battery_80
+i3xrocks.label.battery50: typeface_bar_glyph_battery_50
+i3xrocks.label.battery20: typeface_bar_glyph_battery_20
+i3xrocks.label.battery0: typeface_bar_glyph_battery_0
+i3xrocks.label.batterycharging: typeface_bar_glyph_battery_charging
+i3xrocks.label.batteryac: typeface_bar_glyph_battery_ac
+i3xrocks.label.batteryunknown: typeface_bar_glyph_battery_unknown
+
+i3xrocks.label.time: typeface_bar_glyph_time
+
+i3xrocks.label.mediaplaying: typeface_bar_glyph_media_playing
+i3xrocks.label.mediapaused: typeface_bar_glyph_media_paused
+i3xrocks.value.mediaplayerwidth: 25
+
+i3xrocks.label.notify.none: typeface_bar_glyph_notify_none
+i3xrocks.label.notify.some: typeface_bar_glyph_notify_some
+i3xrocks.label.notify.error: typeface_bar_glyph_notify_error
+
+i3xrocks.label.help: typeface_bar_glyph_help
+
+i3xrocks.label.sound: typeface_bar_glyph_sound
+i3xrocks.label.mute: typeface_bar_glyph_mute
+i3xrocks.label.memory: typeface_bar_glyph_memory
+
+i3xrocks.label.on: typeface_bar_glyph_on
+i3xrocks.label.off: typeface_bar_glyph_off
+
+i3xrocks.label.capslock: typeface_bar_glyph_capslock
+i3xrocks.label.numlock: typeface_bar_glyph_numlock
+
+i3xrocks.weather.error_message: typeface_bar_glyph_error
+
+i3xrocks.label.next-workspace-widget: typeface_bar_glyph_next_workspace
+
+i3xrocks.label.app_launcher: typeface_bar_glyph_app_launcher

--- a/usr/share/regolith-look/i3-default/ilia.css
+++ b/usr/share/regolith-look/i3-default/ilia.css
@@ -1,0 +1,18 @@
+.root_box {
+  margin: 8px;
+}
+
+.filter_entry {
+  border: none;
+  background: none;
+  min-height: 36px;
+  min-width: 320px;
+}
+
+.notebook {
+  border: none;
+}
+
+.keybindings {
+  font-family: DejaVuSansMono Nerd Font;
+}

--- a/usr/share/regolith-look/i3-default/picom.conf
+++ b/usr/share/regolith-look/i3-default/picom.conf
@@ -1,0 +1,245 @@
+#################################
+#
+# Adapted for Regolith from https://gist.github.com/vemacs/458d101ad0bfb79ab70792ecb977c40c
+# Modified per https://github.com/regolith-linux/regolith-desktop/issues/578
+#
+#################################
+
+#################################
+#
+# Backend
+#
+#################################
+
+# Backend to use: "xrender" or "glx".
+# GLX backend is typically much faster but depends on a sane driver.
+backend = "glx";
+
+#################################
+#
+# GLX backend
+#
+#################################
+
+glx-no-stencil = true;
+
+# GLX backend: Copy unmodified regions from front buffer instead of redrawing them all.
+# My tests with nvidia-drivers show a 10% decrease in performance when the whole screen is modified,
+# but a 20% increase when only 1/4 is.
+# My tests on nouveau show terrible slowdown.
+# Useful with --glx-swap-method, as well.
+glx-copy-from-front = false;
+
+# GLX backend: Use MESA_copy_sub_buffer to do partial screen update.
+# My tests on nouveau shows a 200% performance boost when only 1/4 of the screen is updated.
+# May break VSync and is not available on some drivers.
+# Overrides --glx-copy-from-front.
+# glx-use-copysubbuffermesa = true;
+
+# GLX backend: Avoid rebinding pixmap on window damage.
+# Probably could improve performance on rapid window content changes, but is known to break things on some drivers (LLVMpipe).
+# Recommended if it works.
+glx-no-rebind-pixmap = true;
+
+use-damage = true;
+
+# Additionally use X Sync fence to sync clients' draw calls.
+# Needed on nvidia-drivers with GLX backend for some users.
+xrender-sync-fence = true;
+
+#################################
+#
+# Shadows
+#
+#################################
+
+# Enabled client-side shadows on windows.
+shadow = true;
+# The blur radius for shadows. (default 12)
+shadow-radius = 5;
+# The left offset for shadows. (default -15)
+shadow-offset-x = -5;
+# The top offset for shadows. (default -15)
+shadow-offset-y = -5;
+# The translucency for shadows. (default .75)
+shadow-opacity = 0.5;
+
+# Set if you want different colour shadows
+# shadow-red = 0.0;
+# shadow-green = 0.0;
+# shadow-blue = 0.0;
+
+# The shadow exclude options are helpful if you have shadows enabled. Due to the way picom draws its shadows, certain applications will have visual glitches
+# (most applications are fine, only apps that do weird things with xshapes or argb are affected).
+# This list includes all the affected apps I found in my testing. The "! name~=''" part excludes shadows on any "Unknown" windows, this prevents a visual glitch with the XFWM alt tab switcher.
+shadow-exclude = [
+    "! name~=''",
+    "name = 'Notification'",
+    "name = 'Plank'",
+    "name = 'Docky'",
+    "name = 'Kupfer'",
+    "name = 'xfce4-notifyd'",
+    "name *= 'compton'",
+    "name *= 'picom'",
+    "name *= 'cpt_frame_window'",
+    "name *= 'cpt_frame_xcb_window'",
+    "name *= 'wrapper-2.0'",
+    "class_g = 'Conky'",
+    "class_g = 'Kupfer'",
+    "class_g = 'Synapse'",
+    "class_g ?= 'Notify-osd'",
+    "class_g ?= 'Cairo-dock'",
+    "_GTK_FRAME_EXTENTS@:c",
+    "_NET_WM_STATE@:32a *= '_NET_WM_STATE_HIDDEN'"
+];
+# Avoid drawing shadow on all shaped windows (see also: --detect-rounded-corners)
+shadow-ignore-shaped = true;
+
+#################################
+#
+# Opacity
+#
+#################################
+
+inactive-opacity = 1;
+active-opacity = 1;
+frame-opacity = 1;
+inactive-opacity-override = false;
+
+# Dim inactive windows. (0.0 - 1.0)
+inactive-dim = 0.1;
+# Do not let dimness adjust based on window opacity.
+inactive-dim-fixed = true;
+# Blur background of transparent windows. Bad performance with X Render backend. GLX backend is preferred.
+# blur-background = true;
+# Blur background of opaque windows with transparent frames as well.
+# blur-background-frame = true;
+# Do not let blur radius adjust based on window opacity.
+blur-background-fixed = false;
+blur-background-exclude = [
+    "window_type = 'dock'",
+    "window_type = 'desktop'"
+];
+
+#################################
+#           Corners             #
+#################################
+
+# Sets the radius of rounded window corners. When > 0, the compositor will
+# round the corners of windows. Does not interact well with
+# `transparent-clipping`.
+corner-radius = 0
+
+# Exclude conditions for rounded corners.
+rounded-corners-exclude = [
+  "window_type = 'dock'",
+  "window_type = 'desktop'"
+];
+
+#################################
+#
+# Fading
+#
+#################################
+
+# Fade windows during opacity changes.
+fading = true;
+# The time between steps in a fade in milliseconds. (default 10).
+fade-delta = 3;
+# Opacity change between steps while fading in. (default 0.028).
+fade-in-step = 0.03;
+# Opacity change between steps while fading out. (default 0.03).
+fade-out-step = 0.03;
+# Fade windows in/out when opening/closing
+# no-fading-openclose = true;
+
+# Specify a list of conditions of windows that should not be faded.
+fade-exclude = [
+    "name *= 'ilia'"
+];
+
+#################################
+#
+# Other
+#
+#################################
+
+# Try to detect WM windows and mark them as active.
+mark-wmwin-focused = true;
+# Mark all non-WM but override-redirect windows active (e.g. menus).
+mark-ovredir-focused = true;
+# Use EWMH _NET_WM_ACTIVE_WINDOW to determine which window is focused instead of using FocusIn/Out events.
+# Usually more reliable but depends on a EWMH-compliant WM.
+use-ewmh-active-win = true;
+# Detect rounded corners and treat them as rectangular when --shadow-ignore-shaped is on.
+detect-rounded-corners = false;
+
+# Detect _NET_WM_OPACITY on client windows, useful for window managers not passing _NET_WM_OPACITY of client windows to frame windows.
+# This prevents opacity being ignored for some apps.
+# For example without this enabled my xfce4-notifyd is 100% opacity no matter what.
+detect-client-opacity = true;
+
+# Specify refresh rate of the screen.
+# If not specified or 0, picom will try detecting this with X RandR extension.
+refresh-rate = 0;
+
+# Set VSync.
+vsync = true;
+
+# Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
+# Reported to have no effect, though.
+dbe = false;
+
+# Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
+# This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
+# unless you wish to specify a lower refresh rate than the actual value.
+sw-opti = false;
+
+# Unredirect all windows if a full-screen opaque window is detected, to maximize performance for full-screen windows, like games.
+# Known to cause flickering when redirecting/unredirecting windows.
+# paint-on-overlay may make the flickering less obvious.
+unredir-if-possible = true;
+
+# Specify a list of conditions of windows that should always be considered focused.
+focus-exclude = [ ];
+
+# Use WM_TRANSIENT_FOR to group windows, and consider windows in the same group focused at the same time.
+detect-transient = true;
+# Use WM_CLIENT_LEADER to group windows, and consider windows in the same group focused at the same time.
+# WM_TRANSIENT_FOR has higher priority if --detect-transient is enabled, too.
+detect-client-leader = true;
+
+# Prevent shadows from drawing across displays.
+xinerama-shadow-crop = true;
+
+#################################
+#
+# Window type settings
+#
+#################################
+
+wintypes:
+{
+    tooltip =
+    {
+        # fade: Fade the particular type of windows.
+        fade = true;
+        # shadow: Give those windows shadow
+        shadow = false;
+        # opacity: Default opacity for the type of windows.
+        opacity = 0.85;
+        # focus: Whether to always consider windows of this type focused.
+        focus = true;
+    };
+    dock = { shadow = true; }
+    dnd = { shadow = false; }
+    popup_menu = {
+        opacity = 1.0;
+        shadow = false;
+        fade = false;
+    }
+    dropdown_menu = {
+        opacity = 1.0;
+        fade = false;
+    }
+};

--- a/usr/share/regolith-look/i3-default/root
+++ b/usr/share/regolith-look/i3-default/root
@@ -1,0 +1,139 @@
+! --------------------------------------------
+! -- This file is in the Xresource file format
+! --------------------------------------------
+
+! --------------------------------------------
+! -- Look name
+! --------------------------------------------
+
+regolith.look: i3-default
+
+! --------------------------------------------
+! -- Wallpaper 
+! --------------------------------------------
+
+! -- Specify either a complete file path to an image
+
+regolith.wallpaper.file:
+
+!-- *Or* specify a color
+
+regolith.wallpaper.color.primary: #000000
+
+!-- If specifying a primary color, optional additional settings
+
+regolith.wallpaper.color.secondary:
+regolith.wallpaper.color.shading.type: 
+
+! --------------------------------------------
+! -- Theme elements
+! --------------------------------------------
+
+gtk.theme_name: Adwaita-dark
+gtk.icon_theme_name: Adwaita
+
+! --------------------------------------------
+! -- Picom Compositor Config
+! --------------------------------------------
+
+i3-wm.program.compositor: /usr/share/regolith-look/i3-default/compositor-init
+
+! --------------------------------------------
+! -- Fonts
+! --------------------------------------------
+
+#define gtk_font_name DejaVuSansMono Nerd Font 10
+#define gtk_document_font_name DejaVuSansMono Nerd Font 10
+#define gtk_monospace_font_name DejaVuSansMono Nerd Font 10
+
+gtk.font_name: gtk_font_name
+gtk.document_font_name: gtk_document_font_name
+gtk.monospace_font_name: gtk_monospace_font_name
+
+! --------------------------------------------
+! -- Colors
+! --------------------------------------------
+
+! i3-default colors
+
+#define color_terminal_0                            #000000
+#define color_terminal_1                            #c01c28
+#define color_terminal_2                            #26a269
+#define color_terminal_3                            #a2734c
+#define color_terminal_4                            #12488b
+#define color_terminal_5                            #a347ba
+#define color_terminal_6                            #2aa1b3
+#define color_terminal_7                            #d0cfcc
+#define color_terminal_8                            #5e5c64
+#define color_terminal_9                            #f66151
+#define color_terminal_10                           #33da7a
+#define color_terminal_11                           #e9ad0c
+#define color_terminal_12                           #2a7bde
+#define color_terminal_13                           #c061cb
+#define color_terminal_14                           #33c7de
+#define color_terminal_15                           #ffffff
+
+#define color_i3xrocks_label                        #ffffff
+#define color_i3xrocks_value                        #ffffff
+#define color_i3xrocks_critical                     #900000
+#define color_i3xrocks_error                        #a347ba
+#define color_i3xrocks_warning                      #e9ad0c
+#define color_i3xrocks_nominal                      #33da7a
+
+#define color_bar_background                        #000000
+#define color_bar_statusline                        #ffffff
+#define color_bar_separator                         #000000
+#define color_bar_workspace_focused_border          #4c7899
+#define color_bar_workspace_focused_background      #285577 
+#define color_bar_workspace_focused_text            #ffffff
+#define color_bar_workspace_active_border           #4c7899
+#define color_bar_workspace_active_background       #285577
+#define color_bar_workspace_active_text             #ffffff
+#define color_bar_workspace_inactive_border         #333333
+#define color_bar_workspace_inactive_background     #5f676a
+#define color_bar_workspace_inactive_text           #ffffff
+#define color_bar_workspace_urgent_border           #2f343a
+#define color_bar_workspace_urgent_background       #900000
+#define color_bar_workspace_urgent_text             #ffffff
+
+#define color_client_focused_border                 #4c7899
+#define color_client_focused_background             #285577
+#define color_client_focused_text                   #ffffff
+#define color_client_focused_indicator              #2e9ef4
+#define color_client_focused_child_border           #285577
+#define color_client_focused_inactive_border        #333333
+#define color_client_focused_inactive_background    #5f676a
+#define color_client_focused_inactive_text          #ffffff
+#define color_client_focused_inactive_indicator     #484e50
+#define color_client_focused_inactive_child_border  #5f676a
+#define color_client_unfocused_border               #333333
+#define color_client_unfocused_background           #222222
+#define color_client_unfocused_text                 #888888
+#define color_client_unfocused_indicator            #292d2e
+#define color_client_unfocused_child_border         #222222
+#define color_client_urgent_border                  #2f343a
+#define color_client_urgent_background              #900000
+#define color_client_urgent_text                    #ffffff
+#define color_client_urgent_indicator               #900000
+#define color_client_urgent_child_border            #900000
+#define color_client_placeholder_border             #000000
+#define color_client_placeholder_background         #0c0c0c
+#define color_client_placeholder_text               #ffffff
+#define color_client_placeholder_indicator          #000000
+#define color_client_placeholder_child_border       #0c0c0c
+#define color_client_background                     #ffffff
+
+! --------------------------------------------
+! -- Component resources
+! --------------------------------------------
+
+#include "/usr/share/regolith-look/i3-default/i3xrocks"
+#include "/usr/share/regolith-look/i3-default/i3-wm"
+#include "/usr/share/regolith-look/i3-default/gnome-terminal"
+
+! --------------------------------------------
+! -- Loader Path - Path to script responsible 
+! -- for configuring UI from Xres values
+! --------------------------------------------
+
+regolith.look.loader: /usr/share/regolith-look/default_loader.sh

--- a/usr/share/regolith-look/nevil/i3-wm
+++ b/usr/share/regolith-look/nevil/i3-wm
@@ -1,8 +1,10 @@
-#define i3wm_window_border_size         3
-#define i3wm_floatingwindow_border_size 3
-#define i3wm_gaps_inner_size            5
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               bottom
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          3
+#define i3wm_floatingwindow_border_size  3
+#define i3wm_gaps_inner_size             5
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
@@ -56,7 +58,9 @@ i3-wm.client.urgent.color.text: color_base1
 i3-wm.client.urgent.color.indicator: color_red
 i3-wm.client.urgent.color.child_border: color_base00
 
+i3-wm.window.border.style: i3wm_window_border_style
 i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
 i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
 i3-wm.gaps.inner.size: i3wm_gaps_inner_size
 i3-wm.gaps.outer.size: i3wm_gaps_outer_size

--- a/usr/share/regolith-look/nord/i3-wm
+++ b/usr/share/regolith-look/nord/i3-wm
@@ -1,8 +1,10 @@
-#define i3wm_window_border_size         3
-#define i3wm_floatingwindow_border_size 3
-#define i3wm_gaps_inner_size            5
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               bottom
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          3
+#define i3wm_floatingwindow_border_size  3
+#define i3wm_gaps_inner_size             5
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
@@ -52,7 +54,9 @@ i3-wm.client.urgent.color.text: color_base3
 i3-wm.client.urgent.color.indicator: color_red
 i3-wm.client.urgent.color.child_border: color_base03
 
+i3-wm.window.border.style: i3wm_window_border_style
 i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
 i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
 i3-wm.gaps.inner.size: i3wm_gaps_inner_size
 i3-wm.gaps.outer.size: i3wm_gaps_outer_size

--- a/usr/share/regolith-look/solarized-dark/i3-wm
+++ b/usr/share/regolith-look/solarized-dark/i3-wm
@@ -1,8 +1,10 @@
-#define i3wm_window_border_size         1
-#define i3wm_floatingwindow_border_size 1
-#define i3wm_gaps_inner_size            5
-#define i3wm_gaps_outer_size            0
-#define i3wm_bar_position               bottom
+#define i3wm_window_border_style         pixel
+#define i3wm_floatingwindow_border_style pixel
+#define i3wm_window_border_size          1
+#define i3wm_floatingwindow_border_size  1
+#define i3wm_gaps_inner_size             5
+#define i3wm_gaps_outer_size             0
+#define i3wm_bar_position                bottom
 
 #define Q(x) #x
 #define QUOTE(x) Q(x)
@@ -52,7 +54,9 @@ i3-wm.client.urgent.color.text: color_base3
 i3-wm.client.urgent.color.indicator: color_red
 i3-wm.client.urgent.color.child_border: color_base03
 
+i3-wm.window.border.style: i3wm_window_border_style
 i3-wm.window.border.size: i3wm_window_border_size
+i3-wm.floatingwindow.border.style: i3wm_floatingwindow_border_style
 i3-wm.floatingwindow.border.size: i3wm_floatingwindow_border_size
 i3-wm.gaps.inner.size: i3wm_gaps_inner_size
 i3-wm.gaps.outer.size: i3wm_gaps_outer_size


### PR DESCRIPTION
Add i3-default look

New look to emulate the appearance of a default i3 installation.

![i3-default-look](https://user-images.githubusercontent.com/7019630/176736603-077c09ff-cc36-484a-a310-820d51308824.png)

I have also updated the other looks to set the new `i3wm_window_border_style` & `i3wm_floatingwindow_border_style` Xresources to the correct values to ensure it gets set properly when changing between looks.