### PR TITLE
Remove picom as a dependency of Nord and Nevil looks

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -13,7 +13,6 @@ Depends: ${misc:Depends},
   arc-icon-theme,
   fonts-nerd-font-robotomono,
   nordic,
-  picom,
   regolith-look-default
 Provides: regolith-look-2
 Description: Nord look for Regolith
@@ -59,7 +58,6 @@ Depends: ${misc:Depends},
   arc-icon-theme,
   fonts-nerd-font-mononoki,
   whitesur-gtk-theme,
-  picom,
   regolith-look-default
 Provides: regolith-look-2
 Description: A light look for Regolith


### PR DESCRIPTION
I don't really know what I'm doing with deb packaging, but I think I made the right change here.

*Problem*: On several of my systems (some fresh installs of 2.x, some upgrades from 1.x), I have both `regolith-compositor-none` and `picom` packages installed. `picom` is also running on the impacted systems.

My understanding is that while many looks provide `picom` configuration, `picom` should not be a required dependency. It should only be brought in when the user selects the `regolith-compositor-picom-glx` package. Then the look's `picom` config would be used.

If these looks truly depend on `picom`, maybe we should make them instead depend on `regolith-compositor-picom-glx`? This way the user couldn't get in the state of having `regolith-compositor-none` _and_ `picom` both installed. 