### PR TITLE
Make gruvbox i3xrocks values a brighter color

### DIFF
--- a/usr/share/regolith-look/gruvbox/i3xrocks
+++ b/usr/share/regolith-look/gruvbox/i3xrocks
@@ -33,7 +33,7 @@
 #define typeface_bar_glyph_workspace 
 
 i3xrocks.label.color:       color_base0
-i3xrocks.value.color:       color_base00
+i3xrocks.value.color:       color_base3
 i3xrocks.value.font:        gtk_monospace_font_name
 i3xrocks.critical.color:    color_red
 i3xrocks.error.color:       color_orange


### PR DESCRIPTION
I don't know what the protocol is for proposing changes to themes, but this is a change that I've made locally and liked. I thought the previous text color was too close to the background color to be easily readable at a glance.

Before:
![before](https://user-images.githubusercontent.com/3227132/179430204-1db5f1bf-253c-41f3-840e-0ea9bde92fc3.png)



After:
![after](https://user-images.githubusercontent.com/3227132/179430206-35a7ec54-f5e9-4366-9a9c-bce92caa60a4.png)

