### PR TITLE
Cleanup deprecated picom options

### DIFF
--- a/usr/share/regolith-look/ayu-dark/picom.conf
+++ b/usr/share/regolith-look/ayu-dark/picom.conf
@@ -173,21 +173,12 @@ detect-rounded-corners = false;
 # For example without this enabled my xfce4-notifyd is 100% opacity no matter what.
 detect-client-opacity = true;
 
-# Specify refresh rate of the screen.
-# If not specified or 0, picom will try detecting this with X RandR extension.
-refresh-rate = 0;
-
 # Set VSync.
 vsync = true;
 
 # Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
 # Reported to have no effect, though.
 dbe = false;
-
-# Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
-# This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
-# unless you wish to specify a lower refresh rate than the actual value.
-sw-opti = false;
 
 # Unredirect all windows if a full-screen opaque window is detected, to maximize performance for full-screen windows, like games.
 # Known to cause flickering when redirecting/unredirecting windows.

--- a/usr/share/regolith-look/ayu-mirage/picom.conf
+++ b/usr/share/regolith-look/ayu-mirage/picom.conf
@@ -173,21 +173,12 @@ detect-rounded-corners = false;
 # For example without this enabled my xfce4-notifyd is 100% opacity no matter what.
 detect-client-opacity = true;
 
-# Specify refresh rate of the screen.
-# If not specified or 0, picom will try detecting this with X RandR extension.
-refresh-rate = 0;
-
 # Set VSync.
 vsync = true;
 
 # Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
 # Reported to have no effect, though.
 dbe = false;
-
-# Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
-# This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
-# unless you wish to specify a lower refresh rate than the actual value.
-sw-opti = false;
 
 # Unredirect all windows if a full-screen opaque window is detected, to maximize performance for full-screen windows, like games.
 # Known to cause flickering when redirecting/unredirecting windows.

--- a/usr/share/regolith-look/ayu/picom.conf
+++ b/usr/share/regolith-look/ayu/picom.conf
@@ -179,21 +179,12 @@ detect-rounded-corners = false;
 # For example without this enabled my xfce4-notifyd is 100% opacity no matter what.
 detect-client-opacity = true;
 
-# Specify refresh rate of the screen.
-# If not specified or 0, picom will try detecting this with X RandR extension.
-refresh-rate = 0;
-
 # Set VSync.
 vsync = true;
 
 # Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
 # Reported to have no effect, though.
 dbe = false;
-
-# Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
-# This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
-# unless you wish to specify a lower refresh rate than the actual value.
-sw-opti = false;
 
 # Unredirect all windows if a full-screen opaque window is detected, to maximize performance for full-screen windows, like games.
 # Known to cause flickering when redirecting/unredirecting windows.

--- a/usr/share/regolith-look/dracula/picom.conf
+++ b/usr/share/regolith-look/dracula/picom.conf
@@ -179,21 +179,12 @@ detect-rounded-corners = false;
 # For example without this enabled my xfce4-notifyd is 100% opacity no matter what.
 detect-client-opacity = true;
 
-# Specify refresh rate of the screen.
-# If not specified or 0, picom will try detecting this with X RandR extension.
-refresh-rate = 0;
-
 # Set VSync.
 vsync = true;
 
 # Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
 # Reported to have no effect, though.
 dbe = false;
-
-# Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
-# This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
-# unless you wish to specify a lower refresh rate than the actual value.
-sw-opti = false;
 
 # Unredirect all windows if a full-screen opaque window is detected, to maximize performance for full-screen windows, like games.
 # Known to cause flickering when redirecting/unredirecting windows.

--- a/usr/share/regolith-look/i3-default/picom.conf
+++ b/usr/share/regolith-look/i3-default/picom.conf
@@ -179,21 +179,12 @@ detect-rounded-corners = false;
 # For example without this enabled my xfce4-notifyd is 100% opacity no matter what.
 detect-client-opacity = true;
 
-# Specify refresh rate of the screen.
-# If not specified or 0, picom will try detecting this with X RandR extension.
-refresh-rate = 0;
-
 # Set VSync.
 vsync = true;
 
 # Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
 # Reported to have no effect, though.
 dbe = false;
-
-# Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
-# This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
-# unless you wish to specify a lower refresh rate than the actual value.
-sw-opti = false;
 
 # Unredirect all windows if a full-screen opaque window is detected, to maximize performance for full-screen windows, like games.
 # Known to cause flickering when redirecting/unredirecting windows.

--- a/usr/share/regolith-look/nevil/picom.conf
+++ b/usr/share/regolith-look/nevil/picom.conf
@@ -179,21 +179,12 @@ detect-rounded-corners = false;
 # For example without this enabled my xfce4-notifyd is 100% opacity no matter what.
 detect-client-opacity = true;
 
-# Specify refresh rate of the screen.
-# If not specified or 0, picom will try detecting this with X RandR extension.
-refresh-rate = 0;
-
 # Set VSync.
 vsync = true;
 
 # Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
 # Reported to have no effect, though.
 dbe = false;
-
-# Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
-# This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
-# unless you wish to specify a lower refresh rate than the actual value.
-sw-opti = false;
 
 # Unredirect all windows if a full-screen opaque window is detected, to maximize performance for full-screen windows, like games.
 # Known to cause flickering when redirecting/unredirecting windows.

--- a/usr/share/regolith-look/nord/picom.conf
+++ b/usr/share/regolith-look/nord/picom.conf
@@ -179,21 +179,12 @@ detect-rounded-corners = false;
 # For example without this enabled my xfce4-notifyd is 100% opacity no matter what.
 detect-client-opacity = true;
 
-# Specify refresh rate of the screen.
-# If not specified or 0, picom will try detecting this with X RandR extension.
-refresh-rate = 0;
-
 # Set VSync.
 vsync = true;
 
 # Enable DBE painting mode, intended to use with VSync to (hopefully) eliminate tearing.
 # Reported to have no effect, though.
 dbe = false;
-
-# Limit picom to repaint at most once every 1 / refresh_rate second to boost performance.
-# This should not be used with --vsync drm/opengl/opengl-oml as they essentially does --sw-opti's job already,
-# unless you wish to specify a lower refresh rate than the actual value.
-sw-opti = false;
 
 # Unredirect all windows if a full-screen opaque window is detected, to maximize performance for full-screen windows, like games.
 # Known to cause flickering when redirecting/unredirecting windows.


### PR DESCRIPTION
Cleanup deprecated picom options found in any looks.

With Regolith 2.2 I've been getting these in my logs using the `nord` look:

```
[ 12/23/2022 08:17:56.919 parse_config_libconfig WARN ] The refresh-rate option has been deprecated. Please remove it from your configuration file. If you encounter any problems without this feature, please feel free to open a bug report
[ 12/23/2022 08:17:56.919 parse_config_libconfig WARN ] The sw-opti option has been deprecated. Please remove it from your configuration file. If you encounter any problems without this feature, please feel free to open a bug report
```

My picom version is showing as:

```
$ picom --version
vgit-d4e24
```

Same change as https://github.com/regolith-linux/regolith-compositor-picom-glx/pull/6