### PR TITLE
Improve contrast of active vs inactive tabbed mode windows in nord theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # regolith-look-extra
 
-Regolith Looks are discrete configurations of desktop components that together that define the capabilities and flavor of a desktop interface.  There is a package `regolith-look-default` which is the default look and requires minimal dependencies.  This package houses extra looks created and maintained by the Regolith project.
+Regolith Looks are discrete configurations of desktop components that together that
+define the capabilities and flavor of a desktop interface.  There is a package
+`regolith-look-default` which is the default look and requires minimal dependencies.
+This package houses extra looks created and maintained by the Regolith project.
+
+
+## Testing changes to this repo
+
+WARNING: `regolith-look-selector` will not pick up look directories that are symbolic
+links.
+
+TODO: Populate this section.

--- a/usr/share/regolith-look/nord/i3-wm
+++ b/usr/share/regolith-look/nord/i3-wm
@@ -37,14 +37,14 @@ i3-wm.client.focused.color.indicator: color_blue
 i3-wm.client.focused.color.child_border: color_nord4
 
 i3-wm.client.focused_inactive.color.border: color_base03
-i3-wm.client.focused_inactive.color.background: color_base02
-i3-wm.client.focused_inactive.color.text: color_base0
+i3-wm.client.focused_inactive.color.background: color_base03
+i3-wm.client.focused_inactive.color.text: color_base00
 i3-wm.client.focused_inactive.color.indicator: color_base02
 i3-wm.client.focused_inactive.color.child_border: color_base03
 
 i3-wm.client.unfocused.color.border: color_base03
-i3-wm.client.unfocused.color.background: color_base02
-i3-wm.client.unfocused.color.text: color_base0
+i3-wm.client.unfocused.color.background: color_base03
+i3-wm.client.unfocused.color.text: color_base00
 i3-wm.client.unfocused.color.indicator: color_base02
 i3-wm.client.unfocused.color.child_border: color_base03
 

--- a/usr/share/regolith-look/nord/i3-wm
+++ b/usr/share/regolith-look/nord/i3-wm
@@ -36,13 +36,13 @@ i3-wm.client.focused.color.text: color_base3
 i3-wm.client.focused.color.indicator: color_blue
 i3-wm.client.focused.color.child_border: color_nord4
 
-i3-wm.client.focused_inactive.color.border: color_base03
+i3-wm.client.focused_inactive.color.border: color_base01
 i3-wm.client.focused_inactive.color.background: color_base03
 i3-wm.client.focused_inactive.color.text: color_base00
 i3-wm.client.focused_inactive.color.indicator: color_base02
 i3-wm.client.focused_inactive.color.child_border: color_base03
 
-i3-wm.client.unfocused.color.border: color_base03
+i3-wm.client.unfocused.color.border: color_base01
 i3-wm.client.unfocused.color.background: color_base03
 i3-wm.client.unfocused.color.text: color_base00
 i3-wm.client.unfocused.color.indicator: color_base02

--- a/usr/share/regolith-look/nord/root
+++ b/usr/share/regolith-look/nord/root
@@ -80,7 +80,7 @@ gtk.monospace_font_name: gtk_monospace_font_name
 
 ! Nord colors
 #define color_base03   #2E3440
-#define color_base02   #3B4252
+#define color_base02   #2E3440
 #define color_base01   #434C5E
 #define color_base00   #7B8394
 #define color_base0    #D8DEE9

--- a/usr/share/regolith-look/nord/root
+++ b/usr/share/regolith-look/nord/root
@@ -80,7 +80,7 @@ gtk.monospace_font_name: gtk_monospace_font_name
 
 ! Nord colors
 #define color_base03   #2E3440
-#define color_base02   #2E3440
+#define color_base02   #3B4252
 #define color_base01   #434C5E
 #define color_base00   #7B8394
 #define color_base0    #D8DEE9


### PR DESCRIPTION
When using i3's "tabbed" layout, I can't differentiate between the active tab and inactive tabs in this theme (this issue may be specific to my eyeballs or my display settings).

I'm not sure if this is the appropriate place to make that change (e.g. is there another setting that I can change to improve contrast by making the inactive tab background use `base03` instead of `base02` and the active tab background use `base00` instead of `base01`?), unsure if `base03` and `base02` are used together anywhere (this PR makes them the same color), and I'm also unsure if it's OK that the [nord theme](https://www.nordtheme.com/) color `#3b4252` is no longer represented anywhere. So far I haven't noticed any visual issues.

Old:

![image](https://user-images.githubusercontent.com/3608264/209369484-3423a1c7-3fb9-4c02-a7f3-1df363f6b247.png)

New:

![image](https://user-images.githubusercontent.com/3608264/209369140-215324a2-18a2-4909-89c6-93624aed9984.png)
