### PR TITLE
Switch theme `#include`s from absolute paths to relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,26 @@ define the capabilities and flavor of a desktop interface.  There is a package
 This package houses extra looks created and maintained by the Regolith project.
 
 
+## Theme directory conventions
+
+### The `root` file
+
+This is the main theme configuration file. It defines the theme's color palette, fonts,
+wallpaper, compositor settings, and uses
+[C preprocessor `#include` directives](https://gcc.gnu.org/onlinedocs/cpp/Include-Syntax.html)
+to load other config files (window manager config, status bar config, and terminal
+config).
+
+These includes should use relative paths in the following style so themes can be
+portable to other filesystem locations:
+
+```
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
+```
+
+
 ## Testing changes to this repo
 
 WARNING: `regolith-look-selector` will not pick up look directories that are symbolic

--- a/usr/share/regolith-look/ayu-dark/root
+++ b/usr/share/regolith-look/ayu-dark/root
@@ -102,9 +102,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/ayu-dark/i3xrocks"
-#include "/usr/share/regolith-look/ayu-dark/wm"
-#include "/usr/share/regolith-look/ayu-dark/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/ayu-mirage/root
+++ b/usr/share/regolith-look/ayu-mirage/root
@@ -102,9 +102,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/ayu-mirage/i3xrocks"
-#include "/usr/share/regolith-look/ayu-mirage/wm"
-#include "/usr/share/regolith-look/ayu-mirage/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/ayu/root
+++ b/usr/share/regolith-look/ayu/root
@@ -101,9 +101,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/ayu/i3xrocks"
-#include "/usr/share/regolith-look/ayu/wm"
-#include "/usr/share/regolith-look/ayu/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/blackhole/root
+++ b/usr/share/regolith-look/blackhole/root
@@ -93,9 +93,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/blackhole/i3xrocks"
-#include "/usr/share/regolith-look/blackhole/wm"
-#include "/usr/share/regolith-look/blackhole/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/dracula/root
+++ b/usr/share/regolith-look/dracula/root
@@ -103,9 +103,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/dracula/i3xrocks"
-#include "/usr/share/regolith-look/dracula/wm"
-#include "/usr/share/regolith-look/dracula/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/gruvbox/root
+++ b/usr/share/regolith-look/gruvbox/root
@@ -99,9 +99,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/gruvbox/i3xrocks"
-#include "/usr/share/regolith-look/gruvbox/wm"
-#include "/usr/share/regolith-look/gruvbox/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/i3-default/root
+++ b/usr/share/regolith-look/i3-default/root
@@ -151,9 +151,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/i3-default/i3xrocks"
-#include "/usr/share/regolith-look/i3-default/wm"
-#include "/usr/share/regolith-look/i3-default/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/lascaille/root
+++ b/usr/share/regolith-look/lascaille/root
@@ -104,9 +104,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/lascaille/i3xrocks"
-#include "/usr/share/regolith-look/lascaille/wm"
-#include "/usr/share/regolith-look/lascaille/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/nevil/root
+++ b/usr/share/regolith-look/nevil/root
@@ -106,9 +106,9 @@ regolith.compositor.picom.config: /usr/share/regolith-look/nevil/picom.conf
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/nevil/i3xrocks"
-#include "/usr/share/regolith-look/nevil/wm"
-#include "/usr/share/regolith-look/nevil/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/nord/root
+++ b/usr/share/regolith-look/nord/root
@@ -101,9 +101,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/nord/i3xrocks"
-#include "/usr/share/regolith-look/nord/wm"
-#include "/usr/share/regolith-look/nord/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 

--- a/usr/share/regolith-look/solarized-dark/root
+++ b/usr/share/regolith-look/solarized-dark/root
@@ -92,9 +92,9 @@ gtk.monospace_font_name: gtk_monospace_font_name
 ! -- Component resources
 ! --------------------------------------------
 
-#include "/usr/share/regolith-look/solarized-dark/i3xrocks"
-#include "/usr/share/regolith-look/solarized-dark/wm"
-#include "/usr/share/regolith-look/solarized-dark/gnome-terminal"
+#include "i3xrocks"
+#include "wm"
+#include "gnome-terminal"
 
 ! --------------------------------------------
 ! -- Loader Path - Path to script responsible 


### PR DESCRIPTION
Makes themes more portable!

`#include`s in Xresources configuration files are
[C preprocessing directives](https://gcc.gnu.org/onlinedocs/cpp/Include-Syntax.html), which first look in the same directory as the current file.

@kgilmer this is my (very) late follow up on [this](https://github.com/regolith-linux/regolith-look-extra/pull/12#issuecomment-1369390857) discussion.