### PR TITLE
Fix disappearing battery percentage

### DIFF
--- a/usr/share/regolith-look/ayu-dark/i3xrocks
+++ b/usr/share/regolith-look/ayu-dark/i3xrocks
@@ -38,7 +38,7 @@ i3xrocks.value.font:        gtk_monospace_font_name
 i3xrocks.critical.color:    color_red
 i3xrocks.error.color:       color_brightred
 i3xrocks.warning:           color_yellow
-i3xrocks.nominal:           color_black
+i3xrocks.nominal:           color_white
 
 i3xrocks.label.thermometer: typeface_bar_glyph_thermometer
 


### PR DESCRIPTION
The battery symbol is not visible when it falls into a certain percentage range:
![image](https://github.com/user-attachments/assets/497e2fe1-4bbd-49a0-8159-bb0a1477b7ed)

I have tested the fix successfully:
![image](https://github.com/user-attachments/assets/c6c726ac-aafc-4b75-a8a3-61d20c905285)


